### PR TITLE
[BUGFIX] Prevent several warnings when using php7

### DIFF
--- a/Classes/Utility/RecordListUtility.php
+++ b/Classes/Utility/RecordListUtility.php
@@ -135,7 +135,7 @@ class RecordListUtility extends DatabaseRecordList
      * Pseudo fields will be added including the record header.
      * @return string $out: HTML table with the listing for the record.
      */
-    public function getTable($table, $id, $rowList)
+    public function getTable($table, $id, $rowList = '')
     {
         $rowListArray = GeneralUtility::trimExplode(',', $rowList, true);
         // if no columns have been specified, show description (if configured)

--- a/Classes/Utility/TcBeuserUtility.php
+++ b/Classes/Utility/TcBeuserUtility.php
@@ -336,7 +336,7 @@ class TcBeuserUtility
      * Returns the Backend User
      * @return BackendUserAuthentication
      */
-    protected function getBackendUser()
+    protected static function getBackendUser()
     {
         return $GLOBALS['BE_USER'];
     }
@@ -344,7 +344,7 @@ class TcBeuserUtility
     /**
      * @return DatabaseConnection
      */
-    protected function getDatabaseConnection()
+    protected static function getDatabaseConnection()
     {
         return $GLOBALS['TYPO3_DB'];
     }


### PR DESCRIPTION
When using TYPO3 7.6 in development mode on Apache 2.4 with Php7 several php-warnings appear when trying to access tc_beuser-modules in backend. These small adjustments fix them for me. Ext is still working with Php5.6 and Php5.5.
