### PR TITLE
[BUGFIX] Add missing use statement in \dkd\TcBeuser\Utility\RecordListUtility

### DIFF
--- a/Classes/Utility/RecordListUtility.php
+++ b/Classes/Utility/RecordListUtility.php
@@ -31,7 +31,8 @@ use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Type\Bitmask\Permission;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Recordlist\RecordList\DatabaseRecordList;
+use TYPO3\CMS\Recordlist\RecordList\DatabaseRecordList;   
+use TYPO3\CMS\Recordlist\RecordList\RecordListHookInterface;
 
 /**
  * class for listing DB tables in tc_beuser


### PR DESCRIPTION
In Classes/Utility/RecordListUtility.php:651 RecordListHookInterface is references but no namespace is available and the class is not found.