### PR TITLE
Error in SQL syntax for normal users

### DIFF
--- a/Classes/Utility/RecordListUtility.php
+++ b/Classes/Utility/RecordListUtility.php
@@ -303,7 +303,7 @@ class RecordListUtility extends DatabaseRecordList
             $addWhere = (string) $queryBuilder->expr()->andX(
                 $addWhere,
                 $queryBuilder->expr()->eq('admin', 0),
-                $queryBuilder->expr()->notLike('username', '_cli%')
+                $queryBuilder->expr()->notLike('username', "'_cli%'")
             );
         }
 


### PR DESCRIPTION
It fixes SQL syntax error for normal users when they access the list of users.